### PR TITLE
(wip) feat: VPN

### DIFF
--- a/stacks/vpn/.rsyncignore
+++ b/stacks/vpn/.rsyncignore
@@ -1,0 +1,1 @@
+README.md

--- a/stacks/vpn/Corefile
+++ b/stacks/vpn/Corefile
@@ -1,0 +1,9 @@
+.:53 {
+    errors
+    log
+    hosts {
+        10.128.1.10    *.oliverlambson.com
+        fallthrough
+    }
+    forward . 1.1.1.1
+}

--- a/stacks/vpn/README.md
+++ b/stacks/vpn/README.md
@@ -1,0 +1,5 @@
+wireguard vpn + coredns for internal service lookups
+
+https://github.com/linuxserver/docker-wireguard
+
+https://github.com/coredns/coredns

--- a/stacks/vpn/client-template.ini
+++ b/stacks/vpn/client-template.ini
@@ -1,0 +1,11 @@
+[Interface]
+PrivateKey = <client_private_key>
+Address = 10.13.13.0/32
+DNS = 10.128.1.11
+
+[Peer]
+PublicKey = <server_public_key>
+PresharedKey = <preshared_key>
+Endpoint = vpn.oliverlambson.com:51820
+AllowedIPs = 10.0.0.0/16, 10.13.13.0/24
+PersistentKeepalive = 25

--- a/stacks/vpn/compose.yaml
+++ b/stacks/vpn/compose.yaml
@@ -1,0 +1,48 @@
+version: "3.8"
+
+services:
+  coredns:
+    image: coredns/coredns:1.11.3
+    volumes:
+      - ./Corefile:/Corefile
+    networks:
+      private:
+        ipv4_address: 10.128.1.11
+    deploy:
+      replicas: 1
+      placement:
+        constraints:
+          - node.role == manager
+  wireguard:
+    image: linuxserver/wireguard:1.0.20210914
+    cap_add:
+      - NET_ADMIN
+      - SYS_MODULE
+    environment:
+      - PUID=1000
+      - PGID=1000
+      - TZ=Your/Timezone
+      # Optional settings
+      - SERVERURL=vpn.oliverlambson.com
+      - SERVERPORT=51820 # WireGuard port
+      - PEERS=1 # Number of clients
+      - PEERDNS=auto # DNS settings for peers
+      - INTERNAL_SUBNET=10.13.13.0/24 # VPN subnet
+    volumes:
+      - ./config:/config
+      - /lib/modules:/lib/modules:ro
+    ports:
+      - "51820:51820/udp" # is this necessary? can I route vpn through traefik too?
+    networks:
+      - private
+    sysctls:
+      - net.ipv4.conf.all.src_valid_mark=1
+    deploy:
+      replicas: 1
+      placement:
+        constraints:
+          - node.role == manager
+
+networks:
+  private:
+    external: true


### PR DESCRIPTION
wireguard vpn + coredns for dns lookups of internal services when
connected

this should allow for all internal traffic to still be routed through
traefik using IP whitelisting of the VPN

it should also allow for network egress of VPN users only to certain
domains/IPs rather than passing all traffic through the VPN

https://github.com/linuxserver/docker-wireguard

https://github.com/coredns/coredns